### PR TITLE
Fix type errors

### DIFF
--- a/src/audioCore/recovery/Arena.h
+++ b/src/audioCore/recovery/Arena.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include <stdint.h>
+#include <stdlib.h>
 
 typedef struct {
 	char* ptr;

--- a/src/ui/component/config/ConfigPropertyComponents.cpp
+++ b/src/ui/component/config/ConfigPropertyComponents.cpp
@@ -257,7 +257,7 @@ juce::String ConfigTextProp::getText() const {
 		return val.toString();
 	}
 	else if (this->valueType == ValueType::IntVal) {
-		return juce::String{ (int64_t)val };
+		return juce::String{ (juce::int64)val };
 	}
 	else if (this->valueType == ValueType::DoubleVal) {
 		return juce::String{ (double)val };


### PR DESCRIPTION
Fixed some minor type errors.
`size_t` is defined in `<stdlib.h>`, which is not included.
`int64_t` is not the same as `juce::int64` which causes errors in some compilers.