### PR TITLE
Fix segfault

### DIFF
--- a/src/audioCore/action/ActionDispatcher.cpp
+++ b/src/audioCore/action/ActionDispatcher.cpp
@@ -23,9 +23,10 @@ bool ActionDispatcher::dispatch(std::unique_ptr<ActionBase> action) {
 	if (!action) { return false; }
 
 	if (dynamic_cast<ActionUndoableBase*>(action.get())) {
+    	juce::String name = action->getName();
 		//this->manager->beginNewTransaction(action->getName());
 		return this->manager->perform(
-			dynamic_cast<ActionUndoableBase*>(action.release()), action->getName());
+			dynamic_cast<ActionUndoableBase*>(action.release()), name);
 	}
 	return action->doAction();
 }

--- a/src/audioCore/action/ActionDispatcher.cpp
+++ b/src/audioCore/action/ActionDispatcher.cpp
@@ -23,7 +23,7 @@ bool ActionDispatcher::dispatch(std::unique_ptr<ActionBase> action) {
 	if (!action) { return false; }
 
 	if (dynamic_cast<ActionUndoableBase*>(action.get())) {
-    	juce::String name = action->getName();
+		juce::String name = action->getName();
 		//this->manager->beginNewTransaction(action->getName());
 		return this->manager->perform(
 			dynamic_cast<ActionUndoableBase*>(action.release()), name);


### PR DESCRIPTION
Get its name before releasing the action so that it doesn't cause segmentation faults.